### PR TITLE
auto-ready feature

### DIFF
--- a/app/views/manager/restaurants/_settings.html.erb
+++ b/app/views/manager/restaurants/_settings.html.erb
@@ -54,8 +54,9 @@
   </div>
 </div>
 
-<% checkout_toggle = @features.where(key: 'checkout').first %>
-<% group_order_toggle = @features.where(key: 'group_orders').first %>
+<% checkout_toggle = @features.find_by(key: 'checkout') %>
+<% group_order_toggle = @features.find_by(key: 'group_orders') %>
+<% auto_ready_toggle = @features.find_by(key: 'auto_ready') %>
 
 <div class="row">
   <div class="col-sm">
@@ -80,6 +81,17 @@
                           }, disabled: !@restaurant.subscription_enabled %>
         <label for="feature_<%= group_order_toggle.id %>">
           <span><%= group_order_toggle.name %> <small class="text-muted">(Allow group ordering)</small></span>
+          <span></span>
+        </label>
+      </li>
+      <li class="my-3">
+        <%= check_box_tag dom_id(auto_ready_toggle), auto_ready_toggle.id, @restaurant.features.include?(auto_ready_toggle), data: {
+                          remote: true,
+                          url: manager_restaurant_toggle_feature_path(@restaurant.id, auto_ready_toggle.id),
+                          method: :post
+                          }, disabled: !@restaurant.subscription_enabled %>
+        <label for="feature_<%= auto_ready_toggle.id %>">
+          <span><%= auto_ready_toggle.name %> <small class="text-muted">(If you use printers without a screen)</small></span>
           <span></span>
         </label>
       </li>

--- a/db/migrate/20210709093256_add_auto_ready_feature_toggle.rb
+++ b/db/migrate/20210709093256_add_auto_ready_feature_toggle.rb
@@ -1,0 +1,5 @@
+class AddAutoReadyFeatureToggle < ActiveRecord::Migration[6.1]
+  def change
+    Feature.create(key: 'auto_ready', name: 'Auto Ready')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_01_121409) do
+ActiveRecord::Schema.define(version: 2021_07_09_093256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -396,8 +396,6 @@ ActiveRecord::Schema.define(version: 2021_07_01_121409) do
     t.bigint "patron_id", null: false
     t.boolean "emenu_news"
     t.boolean "emenu_promotions"
-    t.boolean "restaurant_news"
-    t.boolean "restaurant_promotions"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["patron_id"], name: "index_patron_marketing_preferences_on_patron_id"
@@ -509,6 +507,16 @@ ActiveRecord::Schema.define(version: 2021_07_01_121409) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["order_id"], name: "index_refunds_on_order_id"
+  end
+
+  create_table "restaurant_patrons", force: :cascade do |t|
+    t.bigint "restaurant_id"
+    t.bigint "patron_id"
+    t.boolean "marketing"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["patron_id"], name: "index_restaurant_patrons_on_patron_id"
+    t.index ["restaurant_id"], name: "index_restaurant_patrons_on_restaurant_id"
   end
 
   create_table "restaurant_tables", force: :cascade do |t|


### PR DESCRIPTION
Feature switch for restaurants with no screens, that only use printers for order management, incoming orders default to 'ready'